### PR TITLE
Update Dockerfile to fix dependencies and sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,39 @@
 FROM python:3-stretch
 
-# set workdir
 WORKDIR /usr/src/app
 
-# install dependencies
-RUN apt-get update && apt-get -y dist-upgrade && \
-	apt-get -y install liblivemedia-dev libjson-c-dev
+# Update sources to archived repositories and remove stretch-updates
+RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian/|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+    sed -i '/stretch-updates/d' /etc/apt/sources.list && \
+    apt-get -o Acquire::Check-Valid-Until=false update && \
+    apt-get -y dist-upgrade && \
+    apt-get -y install liblivemedia-dev libjson-c-dev
 
-# cleanup
+# Clean up
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
 
-# install python dependencies
-RUN pip3 install python-miio
+# Upgrade pip to the latest version
+RUN python3 -m pip install --upgrade pip
 
-# clone code
+# Install an older version of cryptography that doesn't require Rust
+RUN python3 -m pip install cryptography==3.3.2
+
+# Install a compatible version of python-miio
+RUN python3 -m pip install python-miio==0.5.4
+
+# Clone code
 RUN git clone https://github.com/miguelangel-nubla/videoP2Proxy.git .
 
-# build code
+# Build code
 RUN ./autogen.sh
 RUN make
 RUN make install
 
-# run code
+# Run code
 CMD videop2proxy --ip $IP --token $TOKEN --rtsp 8554
 
-# expose port
+# Expose port
 EXPOSE 8554


### PR DESCRIPTION
### Summary

This pull request updates the Dockerfile to address issues related to outdated Debian sources and dependency conflicts that prevent the image from building successfully.

### Changes made:

- Changed Debian sources to point to the Debian Archive since Debian Stretch is no longer actively maintained.
- Removed `stretch-updates` from the sources list as it’s no longer available.

### Dependency Fixes:
- Upgraded pip to the latest version to ensure compatibility with package installations.
- Installed `cryptography==3.3.2` to avoid the need for Rust during installation, which newer versions require.
- Installed `python-miio==0.5.4`, a version compatible with the older dependencies and Python 3.